### PR TITLE
Fix "storage size of 'timer' isn't known" on Debian Squeeze

### DIFF
--- a/ext/fast_stack/fast_stack.c
+++ b/ext/fast_stack/fast_stack.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <sys/time.h>
 #include <ruby.h>
 #include <ruby/encoding.h>
 


### PR DESCRIPTION
struct itimerval defined in sys/time.h
