### PR TITLE
Support Ruby profiling on Windows

### DIFF
--- a/ext/fast_stack/extconf.rb
+++ b/ext/fast_stack/extconf.rb
@@ -5,4 +5,7 @@ require 'fileutils'
 # work around ruby 2.0 p0 bug
 FileUtils.mkdir_p(File.expand_path('../../../lib/fast_stack',__FILE__))
 
+have_func('backtrace_symbols_fd')
+
+
 create_makefile('fast_stack/fast_stack')

--- a/ext/fast_stack/extconf.rb
+++ b/ext/fast_stack/extconf.rb
@@ -6,6 +6,8 @@ require 'fileutils'
 FileUtils.mkdir_p(File.expand_path('../../../lib/fast_stack',__FILE__))
 
 have_func('backtrace_symbols_fd')
+have_func('CreateTimerQueueTimer')
+have_library('winmm', 'timeBeginPeriod')
 
 
 create_makefile('fast_stack/fast_stack')

--- a/ext/fast_stack/fast_stack.c
+++ b/ext/fast_stack/fast_stack.c
@@ -1,91 +1,11 @@
-#include <stdio.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <ruby.h>
-#include <ruby/encoding.h>
-#include <signal.h>
-#include <execinfo.h>
-
-struct sigaction old_alrm;
-int backtrace_fd;
-
-static void alrm_handler(int signum)
-{
-   static void *trace[2048];
-   int n = backtrace(trace, 2048);
-
-   if(n>2){
-       backtrace_symbols_fd(trace + sizeof(void*)*2 , n-2, backtrace_fd);
-       write(backtrace_fd, "__SEP__\n", 8);
-   }
-}
-
-static VALUE
-rb_profile_start_native(VALUE module, VALUE usec, VALUE fd)
-{
-    struct itimerval timer;
-    struct sigaction sa;
-
-    backtrace_fd = NUM2INT(fd);
-    sigaction(SIGALRM, NULL, &old_alrm);
-
-    memset(&sa, 0, sizeof(sa));
-    sa.sa_handler = alrm_handler;
-    sigemptyset(&sa.sa_mask);
-    sigaction(SIGALRM, &sa, NULL);
-
-    timer.it_interval.tv_sec = 0;
-    timer.it_interval.tv_usec = (suseconds_t)NUM2LONG(usec);
-    timer.it_value = timer.it_interval;
-    setitimer(ITIMER_REAL, &timer, 0);
-
-    return Qnil;
-}
-
-
-static VALUE
-rb_profile_stop_native(VALUE module)
-{
-    struct itimerval timer;
-
-    sigaction(SIGALRM, &old_alrm, NULL);
-
-    memset(&timer, 0, sizeof(timer));
-    setitimer(ITIMER_REAL, &timer, 0);
-
-    return Qnil;
-}
-
-static VALUE
-rb_profile_start(VALUE module, VALUE usec)
-{
-    struct itimerval timer;
-
-    timer.it_interval.tv_sec = 0;
-    timer.it_interval.tv_usec = (suseconds_t)NUM2LONG(usec);
-    timer.it_value = timer.it_interval;
-    setitimer(ITIMER_REAL, &timer, 0);
-
-    return Qnil;
-}
-
-static VALUE
-rb_profile_stop(VALUE module)
-{
-    struct itimerval timer;
-    memset(&timer, 0, sizeof(timer));
-    setitimer(ITIMER_REAL, &timer, 0);
-
-    return Qnil;
-}
+#include "fast_stack.h"
 
 void Init_fast_stack( void )
 {
   VALUE rb_mFastStack = rb_define_module("FastStack");
   rb_define_module_function(rb_mFastStack, "start", rb_profile_start, 1);
   rb_define_module_function(rb_mFastStack, "stop", rb_profile_stop, 0);
+  rb_define_module_function(rb_mFastStack, "signal", rb_profile_signal, 0);
 
   rb_define_module_function(rb_mFastStack, "start_native", rb_profile_start_native, 2);
   rb_define_module_function(rb_mFastStack, "stop_native", rb_profile_stop_native, 0);

--- a/ext/fast_stack/fast_stack.h
+++ b/ext/fast_stack/fast_stack.h
@@ -1,0 +1,13 @@
+#ifndef FAST_STACK_H__
+#define FAST_STACK_H__
+
+#include <ruby.h>
+#include <ruby/encoding.h>
+
+VALUE rb_profile_start_native(VALUE module, VALUE usec, VALUE fd);
+VALUE rb_profile_stop_native(VALUE module);
+VALUE rb_profile_start(VALUE module, VALUE usec);
+VALUE rb_profile_stop(VALUE module);
+VALUE rb_profile_signal(VALUE module);
+
+#endif

--- a/ext/fast_stack/fast_stack_linux.c
+++ b/ext/fast_stack/fast_stack_linux.c
@@ -1,0 +1,87 @@
+#ifdef HAVE_BACKTRACE_SYMBOLS_FD
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <signal.h>
+#include <execinfo.h>
+
+#include "fast_stack.h"
+
+struct sigaction old_alrm;
+int backtrace_fd;
+
+static void alrm_handler(int signum)
+{
+   static void *trace[2048];
+   int n = backtrace(trace, 2048);
+
+   if(n>2){
+       backtrace_symbols_fd(trace + sizeof(void*)*2 , n-2, backtrace_fd);
+       write(backtrace_fd, "__SEP__\n", 8);
+   }
+}
+
+VALUE rb_profile_start_native(VALUE module, VALUE usec, VALUE fd)
+{
+    struct itimerval timer;
+    struct sigaction sa;
+
+    backtrace_fd = NUM2INT(fd);
+    sigaction(SIGALRM, NULL, &old_alrm);
+
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = alrm_handler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGALRM, &sa, NULL);
+
+    timer.it_interval.tv_sec = 0;
+    timer.it_interval.tv_usec = (suseconds_t)NUM2LONG(usec);
+    timer.it_value = timer.it_interval;
+    setitimer(ITIMER_REAL, &timer, 0);
+
+    return Qnil;
+}
+
+
+VALUE rb_profile_stop_native(VALUE module)
+{
+    struct itimerval timer;
+
+    sigaction(SIGALRM, &old_alrm, NULL);
+
+    memset(&timer, 0, sizeof(timer));
+    setitimer(ITIMER_REAL, &timer, 0);
+
+    return Qnil;
+}
+
+VALUE rb_profile_start(VALUE module, VALUE usec)
+{
+    struct itimerval timer;
+
+    timer.it_interval.tv_sec = 0;
+    timer.it_interval.tv_usec = (suseconds_t)NUM2LONG(usec);
+    timer.it_value = timer.it_interval;
+    setitimer(ITIMER_REAL, &timer, 0);
+
+    return Qnil;
+}
+
+VALUE rb_profile_stop(VALUE module)
+{
+    struct itimerval timer;
+    memset(&timer, 0, sizeof(timer));
+    setitimer(ITIMER_REAL, &timer, 0);
+
+    return Qnil;
+}
+
+VALUE rb_profile_signal(VALUE module)
+{
+    return rb_str_new_cstr("ALRM");
+}
+
+#endif // HAVE_BACKTRACE_SYMBOLS_FD

--- a/ext/fast_stack/fast_stack_windows.c
+++ b/ext/fast_stack/fast_stack_windows.c
@@ -1,0 +1,58 @@
+#ifdef HAVE_CREATETIMERQUEUETIMER
+
+#include "fast_stack.h"
+
+static VALUE handler_proc;
+static HANDLE timer = NULL;
+
+VALUE rb_profile_start_native(VALUE module, VALUE usec, VALUE fd)
+{
+    rb_raise(rb_eNotImpError, "Not implemented on Windows");
+    return Qnil;
+}
+
+VALUE rb_profile_stop_native(VALUE module)
+{
+    rb_raise(rb_eNotImpError, "Not implemented on Windows");
+    return Qnil;
+}
+
+static void CALLBACK timer_handler(void* handler, BOOLEAN from_timer)
+{
+    raise(SIGINT);
+}
+
+VALUE rb_profile_start(VALUE module, VALUE usec)
+{
+    DWORD interval;
+
+    interval = NUM2LONG(usec) / 1000; /* Windows resolution is in milliseconds */
+
+    timeBeginPeriod(1);
+    if (!CreateTimerQueueTimer(&timer, NULL, &timer_handler, (void*)handler_proc,
+        interval, interval, WT_EXECUTEDEFAULT))
+    {
+        rb_raise(rb_eRuntimeError, "Cannot start timer: %d", GetLastError());
+    }
+
+    return Qnil;
+}
+
+VALUE rb_profile_stop(VALUE module)
+{
+    if (timer)
+    {
+        DeleteTimerQueueTimer(NULL, timer, NULL);
+        timer = NULL;
+    }
+    timeEndPeriod(1);
+
+    return Qnil;
+}
+
+VALUE rb_profile_signal(VALUE module)
+{
+    return rb_str_new_cstr("INT");
+}
+
+#endif // HAVE_CREATETIMERQUEUETIMER

--- a/fast_stack.gemspec
+++ b/fast_stack.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
     'ext/fast_stack/fast_stack.h',
     'ext/fast_stack/fast_stack.c',
     'ext/fast_stack/fast_stack_linux.c',
+    'ext/fast_stack/fast_stack_windows.c',
     'ext/fast_stack/extconf.rb'
   ]
   s.test_files = Dir['spec/**/*_spec.rb']

--- a/fast_stack.gemspec
+++ b/fast_stack.gemspec
@@ -16,7 +16,9 @@ Gem::Specification.new do |s|
     'MIT-LICENSE',
     'README.md',
     'lib/fast_stack.rb',
+    'ext/fast_stack/fast_stack.h',
     'ext/fast_stack/fast_stack.c',
+    'ext/fast_stack/fast_stack_linux.c',
     'ext/fast_stack/extconf.rb'
   ]
   s.test_files = Dir['spec/**/*_spec.rb']

--- a/lib/fast_stack.rb
+++ b/lib/fast_stack.rb
@@ -11,7 +11,7 @@ module FastStack
 
     new_api = thread.respond_to?(:backtrace_locations)
 
-    trap('ALRM') do
+    handler do
       FastStack.stop
       stack = (new_api ? thread.backtrace_locations : thread.backtrace)
       # I am not sure if this is ensured to run in the thread
@@ -35,6 +35,10 @@ module FastStack
 
 
   private
+
+  def self.handler(&block)
+    trap(signal, &block)
+  end
 
   def self.profile_native(millisecs)
     temp = Tempfile.new('stacks')


### PR DESCRIPTION
:)

I have not tested this on Linux, since I'm currently on a Windows machine, but it should work.

It might concern you that I'm using SIGINT on Windows, but on the MSVC runtime (which Mingw uses too) SIGINT is not used by the system. I cannot use SIGALRM because Windows does not have that signal defined, and attempting to use it would cause a parameter validation error in the runtime.

![capture](https://cloud.githubusercontent.com/assets/2505070/9054629/f75addd0-3ab5-11e5-8a79-3b23a86b7877.PNG)
