### PR TITLE
Remove rake dependencies for gem consumers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,6 @@ PATH
   remote: .
   specs:
     fast_stack (0.1.0)
-      rake
-      rake-compiler
 
 GEM
   remote: https://rubygems.org/
@@ -47,4 +45,6 @@ PLATFORMS
 DEPENDENCIES
   fast_stack!
   guard-rspec
+  rake
+  rake-compiler
   rspec

--- a/fast_stack.gemspec
+++ b/fast_stack.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.rubygems_version = '1.3.7'
 
-  s.add_dependency 'rake'
-  s.add_dependency 'rake-compiler'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake-compiler'
 
   s.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
This in response to issue #5 

I did some testing to verify that the gem still installed properly, even when `rake-compiler` was listed as a developer dependency.

I also did a little research to find some evidence of how others use `rake-compiler` to make sure my understanding was correct. [This article](http://tenderlovemaking.com/2009/12/18/writing-ruby-c-extensions-part-1.html) by @tenderlove shows him specifying it as a developer dependency (see the `extra_dev_deps` usage in the code block of the **Modifying the Rakefile** section). Here is [another example in the wild](https://github.com/sinorga/ext_sample/blob/4ab7724d4a882c01f682e32b9e284ac63a78fcc0/ext_sample.gemspec#L24).